### PR TITLE
SSR lint configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node.js",
     "santa.js",
     "santa-es6.js",
+    "santa-ssr.js",
     "santa-test.js"
   ]
 }

--- a/santa-ssr.js
+++ b/santa-ssr.js
@@ -1,6 +1,7 @@
 'use strict';
 // santa ssr package
 module.exports = {
+    "extends": ["./santa.js"],
     "rules": {
         "santa/no-module-state": 2,
         "santa/no-experiment-in-component": 2,

--- a/santa-ssr.js
+++ b/santa-ssr.js
@@ -1,0 +1,15 @@
+'use strict';
+// santa ssr package
+module.exports = {
+    "rules": {
+        "santa/no-module-state": 2,
+        "santa/no-experiment-in-component": 2,
+        "no-restricted-syntax": [
+            "error",
+            {
+                "selector": "CallExpression[callee.type='MemberExpression'][callee.object.name='experiment'][callee.property.name='isOpen'][arguments.length!=2]",
+                "message": "isOpen must always be invoked with two argument."
+            }
+        ],
+    }
+};


### PR DESCRIPTION
# Why
SSR has a specific set of lint rules. Instead of duplicating them across the different eslintrc files, we create a new file and extend that file in the eslintrc file. This way we'll write each lint rule configuration only once.

# What
Moving the lint rules configuration of SSR to a single file. This PR has been tested in the CI [with this santa's pull request.](https://github.com/wix-private/santa/pull/3543)