### PR TITLE
Adding santa-disable-ssr config file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "santa.js",
     "santa-es6.js",
     "santa-ssr.js",
+    "santa-disable-ssr.js",
     "santa-test.js"
   ]
 }

--- a/santa-disable-ssr.js
+++ b/santa-disable-ssr.js
@@ -1,0 +1,16 @@
+'use strict';
+// santa ssr package
+module.exports = {
+    "extends": ["./santa.js"],
+    "rules": {
+        "santa/no-module-state": 0,
+        "santa/no-experiment-in-component": 0,
+        "no-restricted-syntax": [
+            "error",
+            {
+                "selector": "CallExpression[callee.type='MemberExpression'][callee.object.name='experiment'][callee.property.name='isOpen'][arguments.length<1]",
+                "message": "isOpen must always be invoked with at least one argument."
+            }
+        ],
+    }
+};


### PR DESCRIPTION
# Why
Since were enforcing the SSR rules on all of our packages **except** two of them, I'm adding a configuration file that will be used by these two packages, to prevent code duplication. 

# What
New configuration file with the opposite rules of the [santa-ssr configuration file](https://github.com/wix/eslint-config-wix-editor/blob/master/santa-ssr.js)